### PR TITLE
Make line length configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,6 +45,12 @@ name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -89,10 +101,47 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "confy",
  "env_logger",
  "log",
+ "serde",
+ "serde_derive",
+ "serde_yaml",
  "tree-sitter",
  "tree-sitter-clingo",
+]
+
+[[package]]
+name = "confy"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5069e3065d9ad485706017d12bb4b4318170b8087358c163c2dfce50b6b38275"
+dependencies = [
+ "directories",
+ "serde",
+ "thiserror",
+ "toml",
+]
+
+[[package]]
+name = "directories"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "551a778172a450d7fc12e629ca3b0428d00f6afa9a43da1b630d54604e97371c"
+dependencies = [
+ "cfg-if 0.1.10",
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -107,6 +156,23 @@ dependencies = [
  "regex",
  "termcolor",
 ]
+
+[[package]]
+name = "getrandom"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
@@ -130,10 +196,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "indexmap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "log"
@@ -141,7 +223,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -205,6 +287,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +322,41 @@ name = "regex-syntax"
 version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+
+[[package]]
+name = "ryu"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
+name = "serde"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+
+[[package]]
+name = "serde_derive"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
+dependencies = [
+ "indexmap",
+ "ryu",
+ "serde",
+ "yaml-rust",
+]
 
 [[package]]
 name = "strsim"
@@ -245,6 +382,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -280,6 +446,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,3 +481,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,9 +48,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.0.4"
+version = "4.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f78ad8e84aa8e8aa3e821857be40eb4b925ff232de430d4dd2ae6aa058cbd92"
+checksum = "5840cd9093aabeabf7fd932754c435b7674520fc3ddc935c397837050f0f1e4b"
 dependencies = [
  "atty",
  "bitflags",
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.1"
+version = "4.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca689d7434ce44517a12a89456b2be4d1ea1cafcd8f581978c03d45f5a5c12a7"
+checksum = "92289ffc6fb4a85d85c246ddb874c05a87a2e540fb6ad52f7ca07c8c1e1840b1"
 dependencies = [
  "heck",
  "proc-macro-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,9 @@ clap = { version = "4.0", features = ["derive"] }
 anyhow = "1.0"
 log = "0.4"
 env_logger = "0.8.4"
+confy = "0.5"
+serde = "^1.0"
+serde_yaml = { version = "0.8", optional = true }
+serde_derive = "*"
 tree-sitter = "~0.20.0"
 tree-sitter-clingo = "~0.0.10"

--- a/src/bin/clingofmt.rs
+++ b/src/bin/clingofmt.rs
@@ -61,7 +61,7 @@ fn main() {
 
 fn run() -> Result<()> {
     let opt = Opt::parse();
-
+    let cfg: clingofmt::Config = confy::load_path(".clingofmt")?;
     let path = opt.file.to_str().unwrap();
     let source_code =
         fs::read(path).with_context(|| format!("Error reading source file {}", path))?;
@@ -73,7 +73,7 @@ fn run() -> Result<()> {
     let tree = parser.parse(&source_code, None).unwrap();
 
     let mut buf = Vec::new();
-    format_program(&tree, &source_code, &mut buf, opt.debug)?;
+    format_program(&tree, &source_code, &mut buf, opt.debug, &cfg)?;
 
     let mut out = std::io::stdout();
     let buf_str = std::str::from_utf8(&buf)?;

--- a/src/bin/clingofmt.rs
+++ b/src/bin/clingofmt.rs
@@ -49,7 +49,10 @@ impl<'a> io::BufRead for Reader<'a> {
 }
 
 fn main() {
-    env_logger::builder().format_timestamp(None).init();
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Trace)
+        .format_timestamp(None)
+        .init();
     if let Err(err) = run() {
         error!("{:?}", err);
         std::process::exit(1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@ use anyhow::Result;
 use log::{debug, warn};
 use std::io::Write;
 
+const MAX_LENGTH: usize = 10;
+
 #[cfg(test)]
 mod tests;
 struct State {
@@ -221,7 +223,9 @@ fn format_statement(
     out: &mut dyn Write,
     debug: bool,
 ) -> Result<StatementType> {
+    let mut buf: Vec<u8> = vec![];
     let mut flush = false;
+    let mut hard_flush = false;
     let mut cosmetic_ws = false;
     let mut state = State {
         is_show: false,
@@ -340,14 +344,25 @@ fn format_statement(
             }
         } else {
             // What happens after the element
-            if flush {
-                writeln!(out)?;
-                let indent = "    ".repeat(mindent_level);
-                write!(out, "{indent}")?;
-                flush = false
+            if flush || hard_flush {
+                let buf_str = std::str::from_utf8(&buf)?;
+                if buf_str.len() >= MAX_LENGTH || hard_flush {
+                    write!(out, "{}", buf_str)?;
+                    buf.clear();
+                    writeln!(out)?;
+                    let indent = "    ".repeat(mindent_level);
+                    write!(out, "{indent}")?;
+                    flush = false;
+                    hard_flush = false;
+                } else {
+                    write!(out, "{}", buf_str)?;
+                    buf.clear();
+                    write!(out, " ")?;
+                    flush = false;
+                }
             }
             if cosmetic_ws {
-                write!(out, " ")?;
+                write!(buf, " ")?;
                 cosmetic_ws = false
             }
             // Write token to buffer
@@ -356,14 +371,14 @@ fn format_statement(
                 let end_byte = node.end_byte();
                 let text = std::str::from_utf8(&source_code[start_byte..end_byte]).unwrap();
                 if node.kind() == "single_comment" {
-                    write!(out, "{}", text.trim_end())?;
+                    write!(buf, "{}", text.trim_end())?;
                 } else {
-                    write!(out, "{}", text)?;
+                    write!(buf, "{}", text)?;
                 }
             }
 
             match node.kind() {
-                "single_comment" => flush = true,
+                "single_comment" => hard_flush = true,
                 "termvec" | "binaryargvec" => state.in_termvec -= 1,
                 "theory_atom_definition" => {
                     state.in_termvec -= 1;
@@ -391,21 +406,21 @@ fn format_statement(
                 // Add semantic whitespace
                 "NOT" | "aggregatefunction" | "theory_identifier" | "EXTERNAL" | "DEFINED"
                 | "CONST" | "BLOCK" | "PROJECT" | "HEURISTIC" | "THEORY" | "MAXIMIZE"
-                | "MINIMIZE" => write!(out, " ")?,
+                | "MINIMIZE" => write!(buf, " ")?,
                 "INCLUDE" => {
-                    write!(out, " ")?;
+                    write!(buf, " ")?;
                     state.is_include = true;
                 }
                 "SHOW" => {
-                    write!(out, " ")?;
+                    write!(buf, " ")?;
                     state.is_show = true;
                 }
                 // Add cosmetic whitespace
-                "cmp" | "VBAR" => write!(out, " ")?,
+                "cmp" | "VBAR" => write!(buf, " ")?,
                 "SEM" => flush = true,
                 "COLON" => {
                     if state.in_theory_atom_definition | state.is_show {
-                        write!(out, " ")?;
+                        write!(buf, " ")?;
                     } else if state.in_conjunction | state.in_optcondition {
                         mindent_level += 1;
                         flush = true;
@@ -413,7 +428,7 @@ fn format_statement(
                 }
                 "LBRACE" => {
                     if state.in_theory_atom_definition {
-                        write!(out, " ")?;
+                        write!(buf, " ")?;
                     } else {
                         mindent_level += 1;
                         flush = true;
@@ -425,14 +440,14 @@ fn format_statement(
                     {
                         flush = true;
                     } else {
-                        write!(out, " ")?;
+                        write!(buf, " ")?;
                     }
                 }
                 "IF" => {
                     state.has_if = true;
                     mindent_level += 1; // decrease after bodydot
                     if !state.has_head_like {
-                        write!(out, " ")?;
+                        write!(buf, " ")?;
                     } else {
                         flush = true;
                     }
@@ -449,6 +464,8 @@ fn format_statement(
             }
         }
     }
+    let buf_str = std::str::from_utf8(&buf)?;
+    write!(out, "{}", buf_str)?;
     if state.has_head_like & !state.has_body {
         Ok(StatementType::Fact)
     } else if state.is_show {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,13 +358,11 @@ fn format_statement(
                     buf.clear();
                     writeln!(out)?;
                     let indent = "    ".repeat(mindent_level);
-                    write!(out, "{indent}")?;
+                    write!(buf, "{indent}")?;
                     flush = false;
                     hard_flush = false;
                 } else {
-                    write!(out, "{}", buf_str)?;
-                    buf.clear();
-                    write!(out, " ")?;
+                    write!(buf, " ")?;
                     flush = false;
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,7 +452,7 @@ fn format_statement(
                     if !state.has_head_like {
                         write!(buf, " ")?;
                     } else {
-                        flush = true;
+                        hard_flush = true;
                     }
                 }
                 _ => {}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,13 +4,14 @@ use super::*;
 fn fmt_and_cmp(source_code: &str, res: &str) {
     let mut buf = Vec::new();
     let mut parser = tree_sitter::Parser::new();
+    let cfg = Config::default();
     parser
         .set_language(tree_sitter_clingo::language())
         .expect("Error loading clingo grammar");
 
     let tree = parser.parse(&source_code, None).unwrap();
 
-    format_program(&tree, source_code.as_bytes(), &mut buf, false).unwrap();
+    format_program(&tree, source_code.as_bytes(), &mut buf, false, &cfg).unwrap();
     let parse_res = std::str::from_utf8(&buf).unwrap();
     assert_eq!(parse_res, res)
 }


### PR DESCRIPTION
Hey @MaxOstrowski, this PR makes the maximal line length configurable. 
clingofmt will read/create a `.clingofmt` file in TOML format, in this file you can define `line_length = 20`.
Would be nice if you give it a test round. :revolving_hearts: 

 